### PR TITLE
fix(auth): federated sign-out cookie clearing hotfix

### DIFF
--- a/docs/journal/ENTRY-17.md
+++ b/docs/journal/ENTRY-17.md
@@ -1,34 +1,41 @@
 # ENTRY-17 — Logout Cookie Clearing Hotfix (Federated Sign-Out)
-**Date:** 2026-02-28
+
+**Date:** 2026-03-03
 **Type:** Hotfix
-**Branch:** `fix/logout-cookie-clearing`
-**Version:** `1.6.1`
+**Branch:** `fix/logout-cookie-clearing-v2`
+**Version:** `1.8.1`
+**PR:** `docs/pull-requests/PR-fix-logout-cookie-clearing.md`
 
 ---
 
 ## What I Did
 
-Patched `/oauth/logout` so session cookies are cleared on the actual redirect response object, preventing stale auth-server sessions after federated sign-out.
+Patched `/oauth/logout` so session cookies are cleared on the actual redirect response object, preventing stale auth-server sessions after federated sign-out from Career Kit and LSA.
+
+## Root Cause
+
+`cookieStore.delete()` mutations (from `next/headers`) were not carried over to the final `NextResponse.redirect()` response. Auth cookies survived logout, and the next sign-in silently auto-approved due to active auth-server session.
 
 ## Files Touched
 
 | File | Action | Notes |
 |------|--------|-------|
-| `src/app/oauth/logout/route.ts` | Modify | Replaced `cookieStore.delete()` approach with response cookie expiry before return |
-| `docs/pull-requests/PR-1.6.1.md` | Create | PR release documentation |
+| `src/app/oauth/logout/route.ts` | Modify | Replaced `cookies().delete()` with response-bound cookie expiry on redirect |
+| `docs/pull-requests/PR-fix-logout-cookie-clearing.md` | Update | PR documentation |
 
 ## Decisions
 
 - Cleared cookies via `response.cookies.set(..., { expires: new Date(0) })` to guarantee deletions are emitted with `NextResponse.redirect()`.
 - Preserved secure/non-secure cookie handling by setting `secure` dynamically for `__Secure-` names.
 - Kept logout validation behavior unchanged (`id_token_hint`, `client_id`, `post_logout_redirect_uri`, `state`).
+- Rebased onto v1.8.0 main via cherry-pick to avoid carrying duplicate OTP/onboarding commits from the original branch.
 
 ## Still Open
 
-- Run production E2E verification from LSA:
+- Run E2E verification from both Career Kit and LSA:
   - sign in → sign out → confirm auth cookies removed for `auth.manumustudio.com`
   - sign in again → ensure credentials prompt appears (no auto-approve)
-- Deploy and validate LSA-side UX follow-up changes after this auth hotfix is confirmed.
+- Add production `redirectUris` for Career Kit (`https://careerkit.manumustudio.com`) when frontend deploys.
 
 ## Validation
 

--- a/docs/pull-requests/PR-fix-logout-cookie-clearing.md
+++ b/docs/pull-requests/PR-fix-logout-cookie-clearing.md
@@ -1,7 +1,7 @@
-# PR-1.6.1 — Federated Sign-Out Cookie Clearing Hotfix
-**Branch:** `fix/logout-cookie-clearing` → `main`
-**Version:** `1.6.1`
-**Date:** 2026-02-28
+# PR-1.8.1 — Federated Sign-Out Cookie Clearing Hotfix
+**Branch:** `fix/logout-cookie-clearing-v2` → `main`
+**Version:** `1.8.1`
+**Date:** 2026-03-03
 **Status:** ✅ Ready to merge
 
 ---


### PR DESCRIPTION
# PR-1.6.1 — Federated Sign-Out Cookie Clearing Hotfix
**Branch:** `fix/logout-cookie-clearing` → `main`
**Version:** `1.6.1`
**Date:** 2026-02-28
**Status:** ✅ Ready to merge

---

## Summary

Fixes a federated sign-out regression where auth-session cookies were not cleared when returning `NextResponse.redirect()` from `/oauth/logout`. Cookie deletions now happen on the redirect response object via `response.cookies.set(..., { expires: new Date(0) })`, ensuring logout state is actually persisted to the browser.

## Files Changed

| File | Action | Notes |
|------|--------|-------|
| `src/app/oauth/logout/route.ts` | Modified | Replaced `cookies().delete()` pattern with response-bound cookie expiry on redirect |

## Root Cause

- `cookieStore.delete()` mutations (from `next/headers`) were not carried over to the final `NextResponse.redirect()` response.
- Result: auth cookies survived logout, and the next sign-in silently auto-approved due to active auth-server session.

## Fix Details

- Introduced cookie name list and centralized clearing helper:
  - `next-auth.session-token`
  - `__Secure-next-auth.session-token`
  - `next-auth.csrf-token`
  - `__Secure-next-auth.csrf-token`
  - `next-auth.callback-url`
  - `__Secure-next-auth.callback-url`
- Built redirect URL first, then:
  - `const response = NextResponse.redirect(redirectTarget)`
  - clear cookies on `response.cookies.set(...)` with `expires: new Date(0)`
  - return `response`

## Test Plan

- [x] Logout route compiles with updated cookie-clearing path
- [x] `pnpm tsc --noEmit` passes
- [ ] E2E: LSA sign in → sign out → verify auth cookies removed for `auth.manumustudio.com`
- [ ] E2E: Re-sign-in requires credentials (no silent auto-approval)

## Validation

Commands run:

```bash
pnpm tsc --noEmit
```

Results:
- Typecheck: ✅

## Deployment Notes

- No migration required.
- No new environment variables required.
- Must be deployed before validating LSA-side federated sign-out polish changes.
